### PR TITLE
When exporting as html file, headings will be formatted properly (requires getLineHTMLForExport hook)

### DIFF
--- a/ep_headings/ep.json
+++ b/ep_headings/ep.json
@@ -12,7 +12,8 @@
         "aceRegisterBlockElements": "ep_headings/static/js/index"
       },
       "hooks": {
-        "eejsBlock_editbarMenuLeft": "ep_headings/index"
+        "eejsBlock_editbarMenuLeft": "ep_headings/index",
+        "getLineHTMLForExport": "ep_headings/index"
       },
       ".client_hooks": {
         "aceGetFilterStack": "ep_headings/static/js/index:aceGetFilterStack",

--- a/ep_headings/index.js
+++ b/ep_headings/index.js
@@ -1,7 +1,51 @@
-
 var eejs = require('ep_etherpad-lite/node/eejs/');
-
+var Changeset = require("ep_etherpad-lite/static/js/Changeset");
 exports.eejsBlock_editbarMenuLeft = function (hook_name, args, cb) {
-  args.content = args.content + eejs.require("ep_headings/templates/editbarButtons.ejs");
-  return cb();
+    args.content = args.content + eejs.require("ep_headings/templates/editbarButtons.ejs");
+    return cb();
+}
+
+function getFontSize(header) {
+    var fontSize = "2.0";
+    switch (header) {
+    case "h1":
+        fontSize = "2.0";
+        break;
+    case "h2":
+        fontSize = "1.5";
+        break;
+    case "h3":
+        fontSize = "1.17";
+        break;
+    case "h4":
+        fontSize = "";
+        break;
+    case "h5":
+        fontSize = "0.83";
+        break;
+    case "h6":
+        fontSize = "0.75";
+        break;
+    }
+    return fontSize;
+}
+// line, apool,attribLine,text
+exports.getLineHTMLForExport = function (hook, context) {
+    var header = _analyzeLine(context.attribLine, context.apool);
+    if (header) {
+        var fontSize = getFontSize(header);
+        return "<" + header + " style=\"font-size: " + fontSize + "em;line-height: 0.5em;\">" + context.text.substring(1) + "</" + header + ">";
+    }
+}
+
+function _analyzeLine(alineAttrs, apool) {
+    var header = null;
+    if (alineAttrs) {
+        var opIter = Changeset.opIterator(alineAttrs);
+        if (opIter.hasNext()) {
+            var op = opIter.next();
+            header = Changeset.opAttributeValue(op, 'heading', apool);
+        }
+    }
+    return header;
 }


### PR DESCRIPTION
I've made a pull request to Pita's develop branch (https://github.com/Pita/etherpad-lite/pull/943)
