### PR TITLE
prevent heading line style affecting text afterwards

### DIFF
--- a/ep_headings/ep.json
+++ b/ep_headings/ep.json
@@ -13,7 +13,8 @@
       },
       "hooks": {
         "eejsBlock_editbarMenuLeft": "ep_headings/index",
-        "collectContentPre": "ep_headings/static/js/shared"
+        "collectContentPre": "ep_headings/static/js/shared",
+        "collectContentPost": "ep_headings/static/js/shared"
       }
     }
   ]

--- a/ep_headings/static/js/shared.js
+++ b/ep_headings/static/js/shared.js
@@ -7,13 +7,22 @@ var collectContentPre = function(hook, context){
   var state = context.state;
   var lineAttributes = state.lineAttributes
   var tagIndex = _.indexOf(tags, tname);
-  
+
   if(tagIndex >= 0){
     lineAttributes['heading'] = tags[tagIndex];
   }
-  else {
+};
+
+var collectContentPost = function(hook, context){
+  var tname = context.tname;
+  var state = context.state;
+  var lineAttributes = state.lineAttributes
+  var tagIndex = _.indexOf(tags, tname);
+
+  if(tagIndex >= 0){
     delete lineAttributes['heading'];
   }
 };
 
 exports.collectContentPre = collectContentPre;
+exports.collectContentPost = collectContentPost;


### PR DESCRIPTION
if headings are followed by text elements that are not wrapped inside tags, lineAttribute never gets clearer.

to reproduce, create a test pad and: 

```
curl -d apikey=`cat APIKEY.txt` -d 'padID=test' -d 'html=<div><h1>foo</h1>^M<br>^Mfnordfofowersdf</div>' 'http://localhost:28002/api/1/setHTML'
```
