### PR TITLE
Do we need the inline styles?

### DIFF
--- a/ep_headings/index.js
+++ b/ep_headings/index.js
@@ -5,38 +5,11 @@ exports.eejsBlock_editbarMenuLeft = function (hook_name, args, cb) {
   return cb();
 }
 
-function getInlineStyle(header) {
-  switch (header) {
-  case "h1":
-    return "font-size: 2.0em;line-height: 120%;";
-    break;
-  case "h2":
-    return "font-size: 1.5em;line-height: 120%;";
-    break;
-  case "h3":
-    return "font-size: 1.17em;line-height: 120%;";
-    break;
-  case "h4":
-    return "line-height: 120%;";
-    break;
-  case "h5":
-    return "font-size: 0.83em;line-height: 120%;";
-    break;
-  case "h6":
-    return "font-size: 0.75em;line-height: 120%;";
-    break;
-  case "code":
-    return "font-family: monospace";
-  }
-  
-  return "";
-}
 // line, apool,attribLine,text
 exports.getLineHTMLForExport = function (hook, context) {
   var header = _analyzeLine(context.attribLine, context.apool);
   if (header) {
-    var inlineStyle = getInlineStyle(header);
-    return "<" + header + " style=\"" + inlineStyle + "\">" + context.text.substring(1) + "</" + header + ">";
+    return "<" + header + ">" + context.text.substring(1) + "</" + header + ">";
   }
 }
 


### PR DESCRIPTION
Hello

Thanks a bunch for the Headings plugin, which has been quite useful.

I’ve found a qualm with it, though: when using Etherpad as a content editor for blogs et al., programmatically exporting the HTML, the inline styles are something of a nuisance as they override existing CSS.

As it stands, I do not really see the need for the inline styles—when using Etherpad’s HTML export as is, the browser will fall back to the standard header styles, which are pretty similar to what is defined here.

What do you think? 
Thanks for your reply, Cheers,
